### PR TITLE
Fix: Pass proxy to download requests

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -7,7 +7,7 @@ function calcPercents(current, max) {
   return ((current / max) * 100).toFixed(1);
 }
 
-export default async function downloadFile(url, outputPath, subtask, videoId) {
+export default async function downloadFile(url, outputPath, subtask, videoId, proxyData) {
   if (!url) {
     throw new Error("Invalid download link");
   }
@@ -17,6 +17,7 @@ export default async function downloadFile(url, outputPath, subtask, videoId) {
     method: "get",
     url: url,
     responseType: "stream",
+    proxy: proxyData || false,
   });
 
   const totalLength = headers["content-length"];

--- a/src/index.js
+++ b/src/index.js
@@ -358,6 +358,7 @@ async function main() {
                     `${OUTPUT_DIR}/${filename}`,
                     subtask,
                     `(ID: ${videoId} as ${filename})`,
+                    proxyData,
                   )
                     .then(() => {
                       subtask.title = `Download ${taskSubTitle} completed!`;
@@ -411,6 +412,7 @@ async function main() {
                     `${OUTPUT_DIR}/${filename}`,
                     subtask,
                     `(ID: ${videoId} as ${filename})`,
+                    proxyData,
                   )
                     .then(() => {
                       subtask.title = `Download ${taskSubTitle} completed!`;


### PR DESCRIPTION
The --proxy flag was not being used for downloading translated audio from Yandex S3 (vtrans.s3-private.mds.yandex.net), causing ETIMEDOUT errors when direct access to Yandex is blocked.

This change passes the parsed proxyData through to axios download calls in both audio and subtitle download paths.

Fixes downloads behind corporate firewalls and in regions where Yandex services are blocked.

Changes:
- src/download.js: Add proxyData parameter to downloadFile()
- src/index.js: Pass proxyData to both downloadFile() calls

Testing:
  Tested with HTTP proxy on blocked network:
  - Audio translation download: ✅ Works
  - Subtitle download: ✅ Works
  - Without proxy on open network: ✅ Still works (backward compatible)

Manual Testing:

  Tested on Windows 11 with multiple proxy configurations:

  **Test 1: HTTP proxy with auth**
  ```bash
  vot-cli --proxy "http://user:pass@proxy:6114" --output=./test --reslang=ru
  "https://www.youtube.com/watch?v=jNQXAC9IVRw"
  ✅ Audio downloaded successfully through proxy

  Test 2: Without proxy (backward compatibility)
  vot-cli --output=./test --reslang=ru "https://www.youtube.com/watch?v=jNQXAC9IVRw"
  ✅ Works as before (when Yandex is reachable)

  Test 3: Subtitle download with proxy
  vot-cli --proxy "http://user:pass@proxy:6114" --subs --output=./test --reslang=ru
  "https://www.youtube.com/watch?v=jNQXAC9IVRw"
  ✅ Subtitles downloaded through proxy

Impact:
  - No breaking changes - `proxyData` defaults to `false` when not provided
